### PR TITLE
A sprinkling of isset

### DIFF
--- a/Zencoder.php
+++ b/Zencoder.php
@@ -32,12 +32,14 @@ class ZencoderJob {
   function ZencoderJob($params, $options = array()) {
 
     // Build using params if not sending request
-    if($options["build"]) {
+    if(isset($options["build"])) {
       $this->update_attributes($params);
       return true;
     }
     
-    if($options["url"]) $this->new_job_url = $options["url"];
+    if(isset($options["url"])) {
+        $this->new_job_url = $options["url"];
+    }
     $this->new_job_params = $params;
     $this->created = $this->create();
   }
@@ -62,7 +64,7 @@ class ZencoderJob {
       // Create output file objects
       if($attr_name == "outputs" && is_array($attr_value)) {
         $this->create_outputs($attr_value);
-      } elseif (!function_exists($this->$attr_name)) {
+      } elseif (isset($this->$attr_name) && !function_exists($this->$attr_name)) {
         $this->$attr_name = $attr_value;
       }
     }


### PR DESCRIPTION
I noticed a few PHP_NOTICE errors raised when adding a new job (passing empty $options array):

PHP Notice:  Undefined index: build in /Users/chris.rosser/sandbox/ps_kids_and_families/extensions/zencoder/zencoder/Zencoder.php on line 35
PHP Notice:  Undefined index: url in /Users/chris.rosser/sandbox/ps_kids_and_families/extensions/zencoder/zencoder/Zencoder.php on line 40
Notice: Undefined index: url in Zencoder.php on line 40
PHP Notice:  Undefined property: ZencoderJob::$test in /Users/chris.rosser/sandbox/ps_kids_and_families/extensions/zencoder/zencoder/Zencoder.php on line 65
Notice: Undefined property: ZencoderJob::$test in /Users/chris.rosser/sandbox/ps_kids_and_families/extensions/zencoder/zencoder/Zencoder.php on line 65

I've just popped in some isset() to clean these up.

Cheers!

Chris
