### PR TITLE
Region help for developers

### DIFF
--- a/Services/Zencoder.php
+++ b/Services/Zencoder.php
@@ -33,6 +33,14 @@ spl_autoload_register('Services_Zencoder_autoload');
 class Services_Zencoder extends Services_Zencoder_Base
 {
     const USER_AGENT = 'ZencoderPHP v2.1.1';
+    
+    /**
+     * Zencoder Regions development help
+     */
+    const EUROPE_REGION = 'europe';
+    const US_REGION = 'us';
+    const ASIA_REGION = 'asia';
+    
 
     /**
     * Contains the HTTP communication class


### PR DESCRIPTION
Added help constnts to Services_Zencoder class in order to help developers to configure job requests region.
