### PR TITLE
regain compatibility with http2 lowercased header keys

### DIFF
--- a/Services/Zencoder.php
+++ b/Services/Zencoder.php
@@ -232,7 +232,11 @@ class Services_Zencoder extends Services_Zencoder_Base
             return TRUE;
         }
         if (empty($headers['Content-Type'])) {
-            throw new Services_Zencoder_Exception('Response header is missing Content-Type', $body);
+            if (empty($headers['content-type'])) {
+                throw new Services_Zencoder_Exception('Response header is missing Content-Type', $body);
+            } else {
+                $headers['Content-Type'] = $headers['content-type'];
+            }
         }
         switch ($headers['Content-Type']) {
             case 'application/json':


### PR DESCRIPTION
PR addressess issue: https://github.com/zencoder/zencoder-php/issues/29

Affected PHP versions start from PHP 7.1

Please update the README and create a version tag out of it which can be used with composer.