### PR TITLE
Case-insensitive HTTP header parsing

### DIFF
--- a/Services/Zencoder.php
+++ b/Services/Zencoder.php
@@ -231,10 +231,10 @@ class Services_Zencoder extends Services_Zencoder_Base
         if ( $status == 204 || (($status == 200 || $status == 201) && trim($body) == "")) {
             return TRUE;
         }
-        if (empty($headers['Content-Type'])) {
+        if (empty($headers['content-type'])) {
             throw new Services_Zencoder_Exception('Response header is missing Content-Type', $body);
         }
-        switch ($headers['Content-Type']) {
+        switch ($headers['content-type']) {
             case 'application/json':
             case 'application/json; charset=utf-8':
                 return $this->_processJsonResponse($status, $headers, $body);

--- a/Services/Zencoder/Http.php
+++ b/Services/Zencoder/Http.php
@@ -115,7 +115,8 @@ class Services_Zencoder_Http
             array_shift($header_lines);
             foreach ($header_lines as $line) {
               list($key, $value) = explode(":", $line, 2);
-              $headers[$key] = trim($value);
+              // Ensure headers are lowercase per https://tools.ietf.org/html/rfc2616#section-4.2
+              $headers[strtolower($key)] = trim($value);
             }
             curl_close($curl);
             if (isset($buf) && is_resource($buf)) fclose($buf);


### PR DESCRIPTION
This PR updates the HTTP parsing class to ensure that all HTTP header keys are lowercased before returning the result to the caller. This is in-line with RFC2616 and will be compatible with http/2.